### PR TITLE
0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v0.1.1 (2019-2-25)
 
+* Breaking change: Need to define prefix in use statement, or explicitly set to false
+* Verify url with slug does not exceed 60 characters
 * Check for duplicate slugs and raise error if found.
 
 ## v0.1.0 (2019-2-18)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.1.1 (2019-2-25)
+
+* Check for duplicate slugs and raise error if found.
+
 ## v0.1.0 (2019-2-18)
 
 * Initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.1.1 (2019-2-25)
+## v0.1.1 (2019-2-26)
 
 * Breaking change: Need to define prefix in use statement, or explicitly set to false
 * Verify url with slug does not exceed 60 characters

--- a/README.md
+++ b/README.md
@@ -133,6 +133,10 @@ Format your markdown file like so
 
 Store your images in the path `/assets/static/images/blog/{year}/{picture.jpg}` and reference them by the filename only (as seen in the example above).
 
+## Recompiling
+
+You may have occasional issues getting a markdown file recognized after being added or renamed, in this case run `mix recompile --force`.
+
 ## Contributing
 
 I welcome contributions, but please check with me before starting on a pull request - I would hate to have your efforts be in vain.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Add `postex` to your list of dependencies in `mix.exs`:
 
 def deps do
   [
-    {:postex, "~> 0.1.0"}
+    {:postex, "~> 0.1.1"}
   ]
 end
 ```

--- a/lib/blog.ex
+++ b/lib/blog.ex
@@ -1,4 +1,4 @@
 defmodule Blog do
   @moduledoc "For testing only"
-  use Postex
+  use Postex, prefix: "https://postex.com/posts/"
 end

--- a/lib/postex.ex
+++ b/lib/postex.ex
@@ -5,7 +5,9 @@ defmodule Postex do
 
   See the README for more details!
   """
-  defmacro __using__(_opts) do
+  defmacro __using__(opts) do
+    prefix = Keyword.get(opts, :prefix)
+
     quote do
       alias Postex.Post
       alias Postex.Validate
@@ -14,7 +16,11 @@ defmodule Postex do
         Application.ensure_all_started(app)
       end
 
-      # POSTS
+      prefix =
+        unquote(prefix)
+        |> Validate.prefix_defined()
+
+      # Generating posts
 
       posts_paths =
         "posts/**/*.md"
@@ -28,8 +34,11 @@ defmodule Postex do
           Post.parse!(post_path)
         end
         |> Validate.no_duplicate_slugs()
+        |> Validate.url_length(prefix)
 
       @posts Enum.sort_by(posts, & &1.date, {:desc, Date})
+
+      # Posts API
 
       @doc "Returns a list of all the posts"
       @spec list_posts :: [Post.t()]
@@ -57,12 +66,14 @@ defmodule Postex do
         end
       end
 
-      # TAGS
+      # Generating Tags
 
       @tags_with_count posts
                        |> Enum.map(fn post -> post.tags end)
                        |> List.flatten()
                        |> Enum.frequencies()
+
+      # Tags API
 
       @doc "Gets a list of all the tags"
       @spec list_tags :: [binary]

--- a/lib/postex.ex
+++ b/lib/postex.ex
@@ -8,6 +8,7 @@ defmodule Postex do
   defmacro __using__(_opts) do
     quote do
       alias Postex.Post
+      alias Postex.Validate
 
       for app <- [:earmark, :makeup_elixir] do
         Application.ensure_all_started(app)
@@ -26,6 +27,7 @@ defmodule Postex do
           @external_resource Path.relative_to_cwd(post_path)
           Post.parse!(post_path)
         end
+        |> Validate.no_duplicate_slugs()
 
       @posts Enum.sort_by(posts, & &1.date, {:desc, Date})
 

--- a/lib/postex/post.ex
+++ b/lib/postex/post.ex
@@ -2,8 +2,8 @@ defmodule Postex.Post do
   @moduledoc "An individual blog post"
 
   alias Postex.Highlighter
-  @enforce_keys [:id, :author, :title, :body, :description, :tags, :date, :footer]
-  defstruct [:id, :author, :title, :body, :description, :tags, :date, :footer]
+  @enforce_keys [:id, :filename, :author, :title, :body, :description, :tags, :date, :footer]
+  defstruct [:id, :filename, :author, :title, :body, :description, :tags, :date, :footer]
 
   @type t :: %__MODULE__{
           id: binary,
@@ -42,7 +42,7 @@ defmodule Postex.Post do
     # Get all attributes from the contents
     contents = filename |> File.read!() |> parse_contents(year)
     # And finally build the post struct
-    struct!(__MODULE__, [id: id, date: date] ++ contents)
+    struct!(__MODULE__, [id: id, date: date, filename: filename] ++ contents)
   end
 
   defp parse_contents(contents, year) do

--- a/lib/postex/validate.ex
+++ b/lib/postex/validate.ex
@@ -90,6 +90,7 @@ defmodule Postex.Validate do
 
         raise """
         The following posts have addresses that are greater than 60 characters, which negatively impacts SEO.
+        Reference: https://neilpatel.com/blog/seo-urls/
 
         #{posts_message}
         """

--- a/lib/postex/validate.ex
+++ b/lib/postex/validate.ex
@@ -1,4 +1,9 @@
 defmodule Postex.Validate do
+  @moduledoc "For validating at compile time"
+  alias Postex.Post
+
+  @doc "Raises if there are any duplicate slugs"
+  @spec no_duplicate_slugs([Post.t()]) :: [Post.t()]
   def no_duplicate_slugs(posts) do
     unique_slugs =
       posts
@@ -14,7 +19,7 @@ defmodule Postex.Validate do
         |> Kernel.--(unique_slugs)
         |> List.first()
 
-        bad_files =
+      bad_files =
         posts
         |> Enum.filter(fn post -> post.id == bad_slug end)
         |> Enum.map(fn post -> post.filename end)
@@ -30,5 +35,70 @@ defmodule Postex.Validate do
     end
   end
 
+  @doc """
+  Raises unless the prefix is set for the use Macro, i.e.
+
+  ```
+  use Postex, prefix: "https://www.yoursite.com/posts/"
+  ```
+
+  or is explicitly disabled, i.e.
+
+  ```
+  use Postex, prefix: false
+  ```
+  """
+  @spec prefix_defined(binary | nil) :: :ok
+  def prefix_defined(nil) do
+    raise """
+    Please define your post prefix, i.e.
+
+    use Postex, prefix: "https://www.yoursite.com/posts/"
+
+    or explicitly disable with:
+
+    use Postex, prefix: false
+    """
+  end
+
+  def prefix_defined(prefix), do: prefix
+
+  @max_length 60
+
+  @doc """
+    Raises unless all urls (prefix + slug) are less than 60 characters (for SEO) as per [Neil Patel](https://neilpatel.com/blog/seo-urls/).
+
+    Feature can be disabled by setting prefix to `false`
+  """
+  @spec url_length([Post.t()], false | binary) :: [Post.t()]
+  def url_length(posts, false) do
+    posts
+  end
+
+  def url_length(posts, prefix) do
+    too_long = Enum.filter(posts, fn post -> String.length(prefix <> post.id) > @max_length end)
+
+    case too_long do
+      [] ->
+        posts
+
+      posts ->
+        posts_message =
+          posts
+          |> Enum.map(fn post -> url_error_message(post, prefix) end)
+          |> Enum.join("\n\n")
+
+        raise """
+        The following posts have addresses that are greater than 60 characters, which negatively impacts SEO.
+
+        #{posts_message}
+        """
+    end
+  end
+
   defp to_slugs(posts), do: Enum.map(posts, fn post -> post.id end)
+
+  defp url_error_message(post, prefix) do
+    "#{post.filename}:\n#{prefix <> post.id}\n#{String.length(prefix <> post.id)} characters"
+  end
 end

--- a/lib/postex/validate.ex
+++ b/lib/postex/validate.ex
@@ -1,0 +1,34 @@
+defmodule Postex.Validate do
+  def no_duplicate_slugs(posts) do
+    unique_slugs =
+      posts
+      |> to_slugs()
+      |> Enum.uniq()
+
+    if Enum.count(posts) == Enum.count(unique_slugs) do
+      posts
+    else
+      bad_slug =
+        posts
+        |> to_slugs
+        |> Kernel.--(unique_slugs)
+        |> List.first()
+
+        bad_files =
+        posts
+        |> Enum.filter(fn post -> post.id == bad_slug end)
+        |> Enum.map(fn post -> post.filename end)
+        |> Enum.join(", ")
+
+      raise """
+      Duplicate slug #{bad_slug} detected in files:
+
+      #{bad_files}
+
+      Please correct and recompile.
+      """
+    end
+  end
+
+  defp to_slugs(posts), do: Enum.map(posts, fn post -> post.id end)
+end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Postex.MixProject do
   use Mix.Project
 
-  @version "0.1.0"
+  @version "0.1.1"
 
   def project do
     [

--- a/test/postex_test.exs
+++ b/test/postex_test.exs
@@ -1,5 +1,6 @@
 defmodule PostexTest do
   use ExUnit.Case
+  alias Postex.Post
 
   @post %Postex.Post{
     author: "Alan Vardy",
@@ -10,7 +11,8 @@ defmodule PostexTest do
     footer: "_some_footer",
     id: "test-one",
     tags: ["tag one", "three", "two"],
-    title: "Test of the testiest variety"
+    title: "Test of the testiest variety",
+    filename: "posts/2020/03-17-test-one.md"
   }
 
   test "Can get post" do


### PR DESCRIPTION
* Breaking change: Need to define prefix in use statement, or explicitly set to false
* Verify url with slug does not exceed 60 characters
* Check for duplicate slugs and raise error if found.